### PR TITLE
Update heatweathernew2.statuseffect

### DIFF
--- a/stats/effects/fu_weathereffects/new/heat/heatweathernew2.statuseffect
+++ b/stats/effects/fu_weathereffects/new/heat/heatweathernew2.statuseffect
@@ -6,7 +6,7 @@
     "resistanceTypes" : {
       "fireResistance" : 1.0
     },
-    "resistanceThreshold" : 0.25,
+    "resistanceThreshold" : 0.45,
     "immunityStats" : [
       "biomeheatImmunity",
       "ffextremeheatImmunity"


### PR DESCRIPTION
Fixing for typo. heatweathernew.statuseffect has 25% resistance level. All other weather effects follow similar patterns to an increase of 20% per increase in weather effect.